### PR TITLE
Fix Uglify minification error with Safari and ES6 

### DIFF
--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -43,12 +43,12 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 /* istanbul ignore next */
 const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
-  // self-asigning isn't Breaks on safari as if 'str' is declared twice. So renamed arg1
-  let str = String(stri);
+  // fixing safari's strict ES6 issue with duplicate var declarations
+  let str = String(stri), splitted, result, offset, ord;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
-      const splitted = str.split(opt.ignore[i]);
-      const result = [];
+      splitted = str.split(opt.ignore[i]);
+      result = [];
       for (const j in splitted) {
         const ignore = opt.ignore.slice(0);
         ignore.splice(i, 1);
@@ -61,12 +61,12 @@ const transliterate = (stri, options) => {
   const strArr = (0, _utils.ucs2decode)((0, _utils.fixChineseSpace)(str));
   const strArrNew = [];
 
-  for (let ord of strArr) {
+  for (ord of strArr) {
     // These characters are also transliteratable. Will improve it later if needed
     if (ord > 0xffff) {
       strArrNew.push(opt.unknown);
     } else {
-      const offset = ord >> 8;
+      offset = ord >> 8;
       if (typeof codemap[offset] === 'undefined') {
         try {
           codemap[offset] = require(`../../data/x${offset.toString(16)}.json`);

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -41,9 +41,9 @@ const replaceStr = exports.replaceStr = (str, replace) => {
  * @param {object} options options
  */
 /* istanbul ignore next */
-// Artlimes - breaks on safari as if 'str' is declared twice. So renamed arg1
 const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
+  // self-asigning isn't Breaks on safari as if 'str' is declared twice. So renamed arg1
   let str = String(stri);
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -43,16 +43,14 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 /* istanbul ignore next */
 const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
-  // parameter re-assgniment isn't ES6 compatible.
-  // Also breaks because of a safari bug as if 'str' is declared twice
+  // self-asigning isn't Breaks on safari as if 'str' is declared twice. So renamed arg1
   let str = String(stri);
-  let splitted, result, ignore;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
-      splitted = str.split(opt.ignore[i]);
-      result = [];
+      const splitted = str.split(opt.ignore[i]);
+      const result = [];
       for (const j in splitted) {
-        ignore = opt.ignore.slice(0);
+        const ignore = opt.ignore.slice(0);
         ignore.splice(i, 1);
         result.push(transliterate(splitted[j], (0, _utils.mergeOptions)(opt, { ignore, trim: false })));
       }
@@ -77,8 +75,8 @@ const transliterate = (stri, options) => {
         }
       }
       ord &= 0xff;
-      const t = codemap[offset][ord];
-      if (typeof t === 'undefined' || t === null) {
+      const tt = codemap[offset][ord];
+      if (typeof tt === 'undefined' || tt === null) {
         strArrNew.push(opt.unknown);
       } else {
         strArrNew.push(codemap[offset][ord]);

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -37,15 +37,15 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 };
 
 /**
- * @param {string} str The string which is being transliterated
+ * @param {string} stri The string which is being transliterated
  * @param {object} options options
  */
 /* istanbul ignore next */
-const transliterate = (str, options) => {
+const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
   // parameter re-assgniment isn't ES6 compatible.
   // Also breaks because of a safari bug as if 'str' is declared twice
-  let str = String(str);
+  let str = String(stri);
   let splitted, result, ignore;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -45,7 +45,7 @@ const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
   // parameter re-assgniment isn't ES6 compatible.
   // Also breaks on safari as if 'str' is declared twice
-  let str = String(stri);
+  let str = ""+stri;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
       const splitted = str.split(opt.ignore[i]);

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -46,9 +46,10 @@ const transliterate = (stri, options) => {
   // parameter re-assgniment isn't ES6 compatible.
   // Also breaks on safari as if 'str' is declared twice
   let str = ""+stri;
+  let splitted;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
-      const splitted = str.split(opt.ignore[i]);
+      splitted = str.split(opt.ignore[i]);
       const result = [];
       for (const j in splitted) {
         const ignore = opt.ignore.slice(0);

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -44,7 +44,8 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
   // fixing safari's strict ES6 issue with duplicate var declarations
-  let str = String(stri), splitted, result, offset, ord;
+  let str = String(stri);
+  let splitted, result, offset, ord;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
       splitted = str.split(opt.ignore[i]);

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -37,13 +37,14 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 };
 
 /**
- * @param {string} str The string which is being transliterated
+ * @param {string} stri The string which is being transliterated
  * @param {object} options options
  */
 /* istanbul ignore next */
-const transliterate = (str, options) => {
+// Artlimes - breaks on safari as if 'str' is declared twice. So renamed arg1
+const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
-  str = String(str);
+  let str = String(stri);
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
       const splitted = str.split(opt.ignore[i]);

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -37,22 +37,22 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 };
 
 /**
- * @param {string} stri The string which is being transliterated
+ * @param {string} str The string which is being transliterated
  * @param {object} options options
  */
 /* istanbul ignore next */
-const transliterate = (stri, options) => {
+const transliterate = (str, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
   // parameter re-assgniment isn't ES6 compatible.
-  // Also breaks on safari as if 'str' is declared twice
-  let str = ""+stri;
-  let splitted;
+  // Also breaks because of a safari bug as if 'str' is declared twice
+  let str = String(str);
+  let splitted, result, ignore;
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {
       splitted = str.split(opt.ignore[i]);
-      const result = [];
+      result = [];
       for (const j in splitted) {
-        const ignore = opt.ignore.slice(0);
+        ignore = opt.ignore.slice(0);
         ignore.splice(i, 1);
         result.push(transliterate(splitted[j], (0, _utils.mergeOptions)(opt, { ignore, trim: false })));
       }

--- a/lib/node/transliterate.js
+++ b/lib/node/transliterate.js
@@ -43,7 +43,8 @@ const replaceStr = exports.replaceStr = (str, replace) => {
 /* istanbul ignore next */
 const transliterate = (stri, options) => {
   const opt = options ? (0, _utils.mergeOptions)(defaultOptions, options) : (0, _utils.mergeOptions)(defaultOptions, configOptions);
-  // self-asigning isn't Breaks on safari as if 'str' is declared twice. So renamed arg1
+  // parameter re-assgniment isn't ES6 compatible.
+  // Also breaks on safari as if 'str' is declared twice
   let str = String(stri);
   if (opt.ignore instanceof Array && opt.ignore.length > 0) {
     for (const i in opt.ignore) {


### PR DESCRIPTION
Hi there,

Thought we'd let you know that because of an Uglify and Safari bug, Transliteration keeps breaking our app. The problem is with the following https://github.com/mishoo/UglifyJS2/issues/1753

However, as this module does use `const t = codemap[offset][ord];` https://github.com/andyhu/transliteration/blob/master/lib/node/transliterate.js#L77 It does force Uglify to break, and in turn Safari being strict with ES6, will break any app using Transliteration on any Safari mobile or desktop.

The following "suggestion" fixes this issue. 
In short better not use one char variables (except i and j for loops) and for Uglify to work as expected it would want those additional variables to sit outside.

Hope it helps.

credit @artlimes