### PR TITLE
Add `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc


### PR DESCRIPTION
Having `.babelrc` inside package making it impossible to override it.

```
node_modules
|-- transliteration
|   `-- .babelrc
`-- .babelrc
```

When `transliteration` is imported via Webpack, i expect to have options for babel to be used from the root of the project, but in fact babel resolves local `.babelrc` in `node_modules/transliteration`.

This makes all transpilation useless, because module just remain the same, packed with all arrow functions, `const`, and other stuff that completely break build for IE.

`.babelrc` should be removed from package, to avoid this issue.